### PR TITLE
Fix Cylc URL in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cylc Docker
 
-Docker configuration files to set up [Cylc](https://cylc.github.io/cylc)
+Docker configuration files to set up [Cylc](https://cylc.github.io)
 in a standalone, or in a distributed environment.
 
 Licensed under the MIT License.


### PR DESCRIPTION
A massive change! since recent site location changes.